### PR TITLE
fixed ac profile route, ugly pagination for blog-year, spot-header order

### DIFF
--- a/app/blog/routes.py
+++ b/app/blog/routes.py
@@ -57,16 +57,29 @@ def blog_yearmonth_group(year_month):
 
 @bp.route('/blog/year/<string:year>', methods=['GET', 'POST'])
 def blog_year_group(year):
+    per_page = 6
+    # Get the current page from request arguments, defaulting to 1
+    page = request.args.get('page', 1, type=int)
+
     searchform = SearchForm()
     if request.method == 'POST':
         return redirect(url_for('blog.blog_index_search', search_term=searchform.search_term.data))
     posts = blog_posts.query.filter(
         func.substr(blog_posts.post_date, 1, 4) == year
-        ).all()
+    ).paginate(
+        page=page,
+        per_page=per_page,
+        error_out=False,
+    )
 
     context = {
-        'posts' : posts,
+        'posts' : posts.items,
         'form':searchform,
+        'page': page,
+        'year': year,
+        'total_pages': posts.pages,
+        'prev_page': posts.prev_num,
+        'next_page': posts.next_num,
     }
     return render_template('blog/blog_index.html', **context)
 
@@ -93,7 +106,7 @@ def blog_about_this_medium(medium):
         'posts': paginated_posts.items,
         'form': searchform,
         'page': page,
-        'medium':medium,
+        'medium': medium,
         'total_pages': paginated_posts.pages,
         'prev_page': paginated_posts.prev_num,
         'next_page': paginated_posts.next_num,

--- a/app/spotify/art_cat_funcs.py
+++ b/app/spotify/art_cat_funcs.py
@@ -157,9 +157,10 @@ def art_cat_profile(art_id):
     '''
     art_cat_obj = art_id_to_art_cat(art_id)
 
-    both_charts = artist_days_on_both_charts(art_cat_obj.art_name)
+    both_charts = artist_days_on_both_charts(art_cat_obj.art_id)
     dates = [i.date for i in both_charts]
 
+    #USER COMMENTS
     comments = artist_comments.query.filter_by(artist_catalog_id=art_id).all()
 
     art_profile_context = {

--- a/app/spotify/daily_funcs.py
+++ b/app/spotify/daily_funcs.py
@@ -99,21 +99,21 @@ def top_ever_daily_tracks(
     return cream
 
 def artist_days_on_charts(
-        art_name,
+        art_id,
         chart_type):
     '''
     uses the actual model object as the chart_type parameter
 
     art_name is just the string title of the artist
     '''
-    art_days = chart_type.query.filter(chart_type.art_name == art_name).all()
+    art_days = chart_type.query.filter(chart_type.art_id == art_id).all()
     return art_days
 
 def artist_days_on_both_charts(
-        art_name
+        art_id
     ):
-    tracks_days = artist_days_on_charts(art_name, daily_tracks)
-    arts_days = artist_days_on_charts(art_name, daily_artists)
+    tracks_days = artist_days_on_charts(art_id, daily_tracks)
+    arts_days = artist_days_on_charts(art_id, daily_artists)
     return tracks_days + arts_days
 
 def notable_tracks(
@@ -131,11 +131,11 @@ def notable_tracks(
     if track_hits:
         track_titles = [i.song_name for i in track_hits]
         track_ids = [i.song_id for i in track_hits]
+        return list(set(zip(track_titles, track_ids)))
     else:
         return None
 
-    return list(set(zip(track_titles, track_ids)))
-
+    
 def is_one_hit_wonder(
         art_name
     ):
@@ -144,7 +144,7 @@ def is_one_hit_wonder(
         return False
     
     track_hits = notable_tracks(art_name)
-    if len(track_hits) > 1:
+    if track_hits:
         return False
     else:
         return 'One Hit Wonder'

--- a/app/templates/blog/blog_index.html
+++ b/app/templates/blog/blog_index.html
@@ -44,26 +44,50 @@
 </div>
 
 
+{% if medium %}
+    {% if next_page or prev_page %}
+    <div class="mt-3 d-flex" style="justify-content: center;">
+        {% if prev_page %}
+        <span>
+            <a class='prev-post btn btn-secondary' href="{{ url_for('blog.blog_about_this_medium', medium=medium, page=prev_page) }}">
+                {{ 'Previous' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if next_page and prev_page %} || {% endif %}
+        {% if next_page %}
+        <span>
+            <a class='next-post btn btn-secondary' href="{{ url_for('blog.blog_about_this_medium', medium=medium, page=next_page) }}">
+                {{ 'Next' }}
+            </a>
+        </span>
+        {% endif %}
 
-{% if next_page or prev_page %}
-<div class="mt-3 d-flex" style="justify-content: center;">
-    {% if prev_page %}
-    <span>
-        <a class='prev-post btn btn-secondary' href="{{ url_for('blog.blog_about_this_medium', medium=medium, page=prev_page) }}">
-            {{ 'Previous' }}
-        </a>
-    </span>
+    </div>
     {% endif %}
-    {% if next_page and prev_page %} || {% endif %}
-    {% if next_page %}
-    <span>
-        <a class='next-post btn btn-secondary' href="{{ url_for('blog.blog_about_this_medium', medium=medium, page=next_page) }}">
-            {{ 'Next' }}
-        </a>
-    </span>
-    {% endif %}
+{% endif %}
 
-</div>
+{% if year %}
+    {% if next_page or prev_page %}
+    <div class="mt-3 d-flex" style="justify-content: center;">
+        {% if prev_page %}
+        <span>
+            <a class='prev-post btn btn-secondary' href="{{ url_for('blog.blog_year_group', year=year, page=prev_page) }}">
+                {{ 'Previous' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if next_page and prev_page %} || {% endif %}
+        {% if next_page %}
+        <span>
+            <a class='next-post btn btn-secondary' href="{{ url_for('blog.blog_year_group', year=year, page=next_page) }}">
+                {{ 'Next' }}
+            </a>
+        </span>
+        {% endif %}
+
+    </div>
+    {% endif %}
 {% endif %}
 
 {% endblock %}

--- a/app/templates/spotify/spotify_header.html
+++ b/app/templates/spotify/spotify_header.html
@@ -96,8 +96,8 @@
           
               <!-- Dropdown Menu -->
               <div class="dropdown-menu" aria-labelledby="catalogDropdown" style="width: 120px;">
-                  <a class="dropdown-item" href="{{ url_for('spotify.art_cat_landing_page') }}">Artists</a>
                   <a class="dropdown-item" href="{{ url_for('spotify.track_cat_landing_page') }}">Tracks</a>
+                  <a class="dropdown-item" href="{{ url_for('spotify.art_cat_landing_page') }}">Artists</a>
               </div>
             </li>
 


### PR DESCRIPTION
-Using more 'art_id' as a parameter to avoid art_name changes from being lowered or capitalized. This time for the art_cat profile object generator. 

-There is sloppy pagination added to the year group indexing of blog posts. I copied the template for the previous use of paginating blog posts, and hid the new stuff with IF statements in the  template.

-Spotify Header that had dropdowns now match order. That was previously frustrating! 
