### PR TITLE
nav bars, pagination, and hover fx

### DIFF
--- a/app/blog/routes.py
+++ b/app/blog/routes.py
@@ -97,7 +97,7 @@ def blog_about_this_medium(medium):
     
     #posts = blog_posts.query.filter(blog_posts.medium == medium).all()
     paginated_posts = blog_posts.query.filter(blog_posts.medium == medium).order_by(
-        desc(blog_posts.post_date)
+        desc(blog_posts.id)
     ).paginate(
         page=page,
         per_page=per_page,

--- a/app/spotify/routes.py
+++ b/app/spotify/routes.py
@@ -164,20 +164,31 @@ def art_cat_profile(art_id):
 
 @bp.route('/spotify/art_cat/<string:letter>', methods=('GET','POST'))
 def index_by_letter(letter):
+    page = request.args.get('page', 1, type=int)
     form = CourseForm()
     #if form.validate_on_submit():
     if request.method == 'POST':
         return redirect(url_for('spotify.index_by_search', search_term=form.search_term.data))
     
-    art_cat_index = ac_funcs.all_art_cats_starting_with(letter)
+    art_cat_index, total_count = ac_funcs.all_art_cats_starting_with(
+        letter,
+        page,
+        )
     
     context = {
-        'art_cat_index' : art_cat_index,
+        'art_cat_index' : art_cat_index.items,
         'letter' : letter,
         'form':form,
+        'artist_count': total_count,
+        'prev_page':art_cat_index.prev_num,
+        'next_page':art_cat_index.next_num,
+        'first_page':1,
+        'last_page':art_cat_index.pages,
     }
 
     return render_template('spotify/art_cat/art_cat_index.html', **context)
+
+
 
 @bp.route('/spotify/art_cat/genre/<string:master_genre>', methods=('GET','POST'))
 @bp.route('/spotify/art_cat/genre', defaults={'master_genre': None}, methods=('GET','POST'))
@@ -189,18 +200,20 @@ def index_by_genre(master_genre):
         return redirect(url_for('spotify.index_by_search', search_term=form.search_term.data))
     
     if (master_genre in ac_funcs.genres)|(master_genre is None) :
-        #art_cat_index = ac_funcs.all_art_cats_in_master_genre(master_genre, page)
-        art_cat_index = ac_funcs.all_art_cats_in_master_genre(master_genre)    
+        art_cat_index, ac_count = ac_funcs.all_art_cats_in_master_genre(master_genre, page)    
     else:
-        #art_cat_index = ac_funcs.art_cats_with_this_genre(master_genre, page)
-        art_cat_index = ac_funcs.art_cats_with_this_genre(master_genre)
+        art_cat_index, ac_count = ac_funcs.art_cats_with_this_genre(master_genre, page)
+
 
     context = {
         'genre': master_genre,
-        'art_cat_index': art_cat_index,
+        'artist_count': ac_count,
+        'art_cat_index': art_cat_index.items,
         'form':form,
-        #'prev_page':art_cat_index.prev_num,
-        #'next_page':art_cat_index.next_num,
+        'prev_page':art_cat_index.prev_num,
+        'next_page':art_cat_index.next_num,
+        'first_page':1,
+        'last_page':art_cat_index.pages,
     }
 
     return render_template('spotify/art_cat/art_cat_index.html', **context)
@@ -355,3 +368,24 @@ def arts_prev(year, month, day):
     )
     return render_template('spotify/archive_chart_artists.html', **context)
 
+
+
+
+'''
+@bp.route('/spotify/art_cat/<string:letter>', methods=('GET','POST'))
+def index_by_letterOLD(letter):
+    form = CourseForm()
+    #if form.validate_on_submit():
+    if request.method == 'POST':
+        return redirect(url_for('spotify.index_by_search', search_term=form.search_term.data))
+    
+    art_cat_index = ac_funcs.all_art_cats_starting_with(letter)
+    
+    context = {
+        'art_cat_index' : art_cat_index,
+        'letter' : letter,
+        'form':form,
+    }
+
+    return render_template('spotify/art_cat/art_cat_index.html', **context)
+'''

--- a/app/templates/spotify/art_cat/art_cat_index.html
+++ b/app/templates/spotify/art_cat/art_cat_index.html
@@ -4,20 +4,25 @@
 <link rel='stylesheet' type='text/css' href="{{ url_for('static', filename='css/spotify.css') }}">
 
 <style>
+.genre-highlight {
+    font-weight: bold;
+    color: #00ffbf; /* Change this to the desired color */
+}
+
 
 </style>
 
-<div class="container text-center">
 
-    {% if art_cat_index is not defined or art_cat_index|length == 0 %}
-    <p>The variable is empty or undefined.</p>
-    {% else %}
-    {% if letter is defined %}
-    <p>{{ art_cat_index|length }} artists when indexed by {{ letter }}</p>
-    {% elif genre is defined %}
-    <p>{{ art_cat_index|length }} artists when indexed by {{ genre }}</p>
-    {% endif %}
-    {% endif %}
+
+
+<div class="container text-center">
+    <div class="row mb-3">
+        <div class="col-12">
+            <h4><span class="genre-highlight"> {{ artist_count }} </span> artists indexed by <span class="genre-highlight">{{ genre or letter}}</span></h4>
+        </div>
+    </div>
+
+    {% include 'spotify/art_cat/art_cat_nav_buttons.html' %}
 
     <div class="row">
         {% for item in art_cat_index %}
@@ -28,25 +33,7 @@
     </div>
 </div>
 
-{% if next_page or prev_page %}
-<div class="mt-3 d-flex" style="justify-content: center;">
-    {% if prev_page %}
-    <span>
-        <a class='prev-post btn btn-secondary' href="{{ url_for('spotify.index_by_genre', master_genre=genre, page=prev_page) }}">
-            {{ 'Previous' }}
-        </a>
-    </span>
-    {% endif %}
-    {% if next_page and prev_page %} || {% endif %}
-    {% if next_page %}
-    <span>
-        <a class='next-post btn btn-secondary' href="{{ url_for('spotify.index_by_genre', master_genre=genre, page=next_page) }}">
-            {{ 'Next' }}
-        </a>
-    </span>
-    {% endif %}
+{% include 'spotify/art_cat/art_cat_nav_buttons.html' %}
 
-</div>
-{% endif %}
 
 {% endblock %}

--- a/app/templates/spotify/art_cat/art_cat_index_cards.html
+++ b/app/templates/spotify/art_cat/art_cat_index_cards.html
@@ -1,5 +1,23 @@
-
 <style>
+    .card {
+        position: relative;
+        width: 18rem;
+    }
+
+    .card-img-top {
+        max-height: 250px;
+        object-fit: cover;
+        transition: filter 0.3s ease; /* Add transition effect for the filter */
+    }
+
+    .card:hover .card-img-top {
+        filter: saturate(190%) hue-rotate(40deg); /* Adjust saturation and hue rotation */
+    }
+
+    .card-body {
+        padding: 1rem;
+    }
+
     .my-item {
         transition: box-shadow 0.3s ease;
     }
@@ -8,48 +26,44 @@
         box-shadow: inset 0 0 50px rgba(0, 0, 0, 0.5); /* Adjust the shadow color and size as needed */
     }
 
-    .card-img-top {
-        max-height: 250px; /* Adjust the maximum height of the image */
-        object-fit: cover;
+    .my-item-header {
+        font-size: 1.2rem;
+        margin-top: 0.5rem;
     }
 </style>
 
 <div class="col-md-3" style="padding-top: 30px;">
-    <div class="card" style="width: 18rem;">
+    <div class="card">
         <a href="{{ url_for('spotify.art_cat_profile', art_id=item.art_id) }}">
-
-    {% if item.img_url_mid == '' %}
-        <img src="{{ url_for('static', filename='/img/fallback.jpeg') }}" class="card-img-top my-image" alt="{{ item.art_name }}">
-    {% else %}
-    <!-- Fallback image from the static folder -->
-        <img src="https://i.scdn.co/image/{{ item.img_url_mid }}" class="card-img-top my-image" alt="{{ item.art_name }}">
-    {% endif %}
-
-        <div class="card-body my-item">
-            
-            {% if item.master_genre == 'rock' %}
-                <h3 class="my-item-header rock">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'pop' %}
-                <h3 class="my-item-header pop">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'electronic' %}
-                <h3 class="my-item-header electronic">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'punk' %}
-                <h3 class="my-item-header punk">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'funk' %}
-                <h3 class="my-item-header funk">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'indie' %}
-                <h3 class="my-item-header indie">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'old' %}
-                <h3 class="my-item-header old">{{ item.art_name }}</h3>
-            {% elif item.master_genre == 'country' %}
-                <h3 class="my-item-header country">{{ item.art_name }}</h3>
+            {% if item.img_url_mid %}
+                <img src="https://i.scdn.co/image/{{ item.img_url_mid }}" class="card-img-top" alt="{{ item.art_name }}">
             {% else %}
-                <h3 class="my-item-header" style="background-color: w">{{ item.art_name }}</h3>
+                <img src="{{ url_for('static', filename='favicon-32x32.png') }}" class="card-img-top" alt="{{ item.art_name }}">
             {% endif %}
 
-            <b><p class="card-text">{{ item.genre }}</p></b>
-            
-        </div>
+            <div class="card-body my-item">
+                {% if item.master_genre == 'rock' %}
+                    <h3 class="my-item-header rock">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'pop' %}
+                    <h3 class="my-item-header pop">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'electronic' %}
+                    <h3 class="my-item-header electronic">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'punk' %}
+                    <h3 class="my-item-header punk">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'funk' %}
+                    <h3 class="my-item-header funk">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'indie' %}
+                    <h3 class="my-item-header indie">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'old' %}
+                    <h3 class="my-item-header old">{{ item.art_name }}</h3>
+                {% elif item.master_genre == 'country' %}
+                    <h3 class="my-item-header country">{{ item.art_name }}</h3>
+                {% else %}
+                    <h3 class="my-item-header">{{ item.art_name }}</h3>
+                {% endif %}
+
+                <p class="card-text">{{ item.genre }}</p>
+            </div>
         </a>
     </div>
 </div>

--- a/app/templates/spotify/art_cat/art_cat_nav_buttons.html
+++ b/app/templates/spotify/art_cat/art_cat_nav_buttons.html
@@ -1,0 +1,63 @@
+{% if next_page or prev_page %}
+<div class="mt-3 d-flex justify-content-center">
+    {% if genre %}
+        {% if first_page %}
+        <span>
+            <a class='first-page btn btn-primary' href="{{ url_for('spotify.index_by_genre', master_genre=genre, page=first_page) }}">
+                {{ '<<' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if prev_page %}
+        <span style="margin-left: 10px;">
+            <a class='prev-post btn btn-secondary' href="{{ url_for('spotify.index_by_genre', master_genre=genre, page=prev_page) }}">
+                {{ 'Previous' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if next_page %}
+        <span style="margin-left: 10px;">
+            <a class='next-post btn btn-secondary' href="{{ url_for('spotify.index_by_genre', master_genre=genre, page=next_page) }}">
+                {{ 'Next' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if last_page %}
+        <span style="margin-left: 10px;">
+            <a class='last-page btn btn-primary' href="{{ url_for('spotify.index_by_genre', master_genre=genre, page=last_page) }}">
+                {{ '>>' }}
+            </a>
+        </span>
+        {% endif %}
+    {% elif letter %}
+        {% if first_page %}
+        <span>
+            <a class='first-page btn btn-primary' href="{{ url_for('spotify.index_by_letter', letter=letter, page=first_page) }}">
+                {{ '<<' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if prev_page %}
+        <span style="margin-left: 10px;">
+            <a class='prev-post btn btn-secondary' href="{{ url_for('spotify.index_by_letter', letter=letter, page=prev_page) }}">
+                {{ 'Previous' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if next_page %}
+        <span style="margin-left: 10px;">
+            <a class='next-post btn btn-secondary' href="{{ url_for('spotify.index_by_letter', letter=letter, page=next_page) }}">
+                {{ 'Next' }}
+            </a>
+        </span>
+        {% endif %}
+        {% if last_page %}
+        <span style="margin-left: 10px;">
+            <a class='last-page btn btn-primary' href="{{ url_for('spotify.index_by_letter', letter=letter, page=last_page) }}">
+                {{ '>>' }}
+            </a>
+        </span>
+        {% endif %}
+    {% endif %}
+</div>
+{% endif %}


### PR DESCRIPTION
-Navbars are there own template now. They are big. 

-Art_cat routes are paginated. 12 per page. In the context there is now a
first, last, prev, next page

-template is split between linking index_by_genre or index_by_letter

Also fixed ordering of blog routes. The id is good enough for sorting by date.

A NEW 'The ' exception needs to be written so that they're distributed to their appropriate letter. ex. R for The Rolling Stones. That got broken!