### PR TITLE
hotfix for the spotify header nav options for genre

### DIFF
--- a/app/templates/spotify/spotify_header.html
+++ b/app/templates/spotify/spotify_header.html
@@ -98,6 +98,7 @@
               <div class="dropdown-menu" aria-labelledby="catalogDropdown" style="width: 120px;">
                   <a class="dropdown-item" href="{{ url_for('spotify.track_cat_landing_page') }}">Tracks</a>
                   <a class="dropdown-item" href="{{ url_for('spotify.art_cat_landing_page') }}">Artists</a>
+                  <a class="dropdown-item" href="{{ url_for('spotify.genres_landing_page') }}">Genres</a>
               </div>
             </li>
 


### PR DESCRIPTION
fixing spotify header navbar for genre