### PR TITLE
adding hourly cache to global tracks dash

### DIFF
--- a/app/dash_plotlys/dash_apps/country_today_tracks.py
+++ b/app/dash_plotlys/dash_apps/country_today_tracks.py
@@ -94,7 +94,8 @@ def Add_Dash_today_tracks_in_country(flask_app):
             className="h-100",  # Make the row take up the full height
             style={'min-height': '80vh'}  # Ensures the row has a minimum height for centering
         ),
-        layouts.my_icon
+        layouts.my_icon,
+        dcc.Interval(id='interval-component', interval=3600000, n_intervals=0),  # 1 hour interval
     ])
 
 
@@ -106,9 +107,10 @@ def Add_Dash_today_tracks_in_country(flask_app):
     @dash_app.callback(
         [Output('top10-today-list', 'children'),
          Output('line-plot', 'figure')],
-        [Input('category-dropdown', 'value')]
+        [Input('category-dropdown', 'value'),
+        Input('interval-component', 'n_intervals')]
     )
-    def dropdown_change_all_output(selected_country):
+    def dropdown_change_all_output(selected_country, n_intervals):
         country_components = global_stats.Country_Dash_Components(
             selected_country,
             db

--- a/app/dash_plotlys/global_stats.py
+++ b/app/dash_plotlys/global_stats.py
@@ -2,7 +2,7 @@ import pandas as pd
 import sqlite3
 import json
 
-with open('global_spotify/country_codes.json', 'r') as json_file:
+with open('/home/flambuth/fredlambuthPUNTOcom/global_spotify/country_codes.json', 'r') as json_file:
     country_dict = json.load(json_file)
 
 def get_country_string(country_code):


### PR DESCRIPTION
I am embarrased by teh use of hardcoded file paths. One day I'll fix all of them.

global_stats now uses an absolute path for the country codes json

in 'todays_tracks' I added a div item to the layout that is connected to a new callback feature that checks the time interval